### PR TITLE
remove self from root .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "presets": ["env", "stage-0", "react"],
-  "plugins": ["./lib/babel.js"]
+  "presets": ["env", "stage-0"]
 }

--- a/example/.babelrc
+++ b/example/.babelrc
@@ -1,0 +1,4 @@
+{
+  "presets": ["env", "stage-0", "react"],
+  "plugins": ["../lib/babel.js"]
+}


### PR DESCRIPTION
When doing a fresh checkout the plugin referenced in the babel config
does not exist yet and the build fails.  This PR splits the .babelrc
file into two (one for the lib, one for the example).