### PR TITLE
Export as ES Modules

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,8 @@
 {
-  "presets": ["env", "stage-0"]
+  "presets": [["env", { "modules": false }], "stage-0"],
+  "env": {
+    "commonjs": {
+      "presets": ["env", "stage-0"]
+    }
+  }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ xcuserdata
 CVS
 node_modules
 lib
+es
 example/*bundle*
 dist
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "4.0.4",
   "description": "css-in-js. again.",
   "main": "lib/index.js",
+  "module": "es/index.js",
+  "jsnext:main": "es/index.js",
   "author": "Sunil Pai <threepointone@gmail.com>",
   "repository": {
     "type": "git",
@@ -23,7 +25,7 @@
   "scripts": {
     "dev": "npm run build && npm start",
     "start": "webpack-dev-server",
-    "build": "babel src -d lib",
+    "build": "BABEL_ENV=commonjs babel src -d lib && babel src -d es",
     "umd": "webpack --config webpack.umd.js -p ",
     "test": "jest --coverage",
     "snapshot": "npm test -- -u",


### PR DESCRIPTION
This allows `glam` to be scope hoisted with rollup and [webpack 3's scope hoisting](https://medium.com/webpack/webpack-3-official-release-15fd2dd8f07b)